### PR TITLE
correct the docstring of the `rl_env_start`

### DIFF
--- a/RLGlue/rl_glue.py
+++ b/RLGlue/rl_glue.py
@@ -81,8 +81,7 @@ class RLGlue:
         """Starts RL-Glue environment.
 
         Returns:
-            (float, state, Boolean): reward, state observation, boolean
-                indicating termination
+            state: a one dimensional state representation of the agent location.
         """
         self.total_reward = 0.0
         self.num_steps = 1


### PR DESCRIPTION
The `env_start` method returns only the state (at least according to the code of the cliff walk environment). 